### PR TITLE
Disabled tracepoint is now EBADF

### DIFF
--- a/eventheader/src/changelog.rs
+++ b/eventheader/src/changelog.rs
@@ -3,6 +3,12 @@
 #[allow(unused_imports)]
 use crate::*; // For docs
 
+/// # v0.3.0 (2023-06-26)
+/// - If no consumers have enabled a tracepoint, the kernel now returns
+///   `EBADF`. The eventheader crate has been updated to be consistent with
+///   the new behavior.
+pub mod v0_3_0 {}
+
 /// # v0.2.0 (2023-05-16)
 /// - Add support for macro-based logging.
 pub mod v0_2_0 {}

--- a/eventheader/src/descriptors.rs
+++ b/eventheader/src/descriptors.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 use core::marker::PhantomData;
-use core::mem::size_of;
+use core::mem;
 
 use crate::enums::ExtensionKind;
 use crate::enums::HeaderFlags;
@@ -204,7 +204,7 @@ impl<'a> EventDataDescriptor<'a> {
     pub fn from_value<T: Copy>(value: &'a T) -> Self {
         return Self {
             ptr: value as *const T as usize,
-            size: size_of::<T>(),
+            size: mem::size_of::<T>(),
             lifetime: PhantomData,
         };
     }
@@ -238,7 +238,7 @@ impl<'a> EventDataDescriptor<'a> {
 
         return Self {
             ptr: value.as_ptr() as usize,
-            size: size_of::<T>() * value.len(),
+            size: mem::size_of_val(value),
             lifetime: PhantomData,
         };
     }
@@ -258,7 +258,7 @@ impl<'a> EventDataDescriptor<'a> {
 
         return Self {
             ptr: value.as_ptr() as usize,
-            size: size_of::<T>() * value.len(),
+            size: mem::size_of_val(value),
             lifetime: PhantomData,
         };
     }

--- a/eventheader/src/lib.rs
+++ b/eventheader/src/lib.rs
@@ -404,7 +404,7 @@ pub use eventheader_macros::define_provider;
 ///
 /// ```ignore
 /// if !MY_PROVIDER.enabled(event_level, event_keyword) {
-///     0
+///     9 // EBADF
 /// } else {
 ///     writev(MY_PROVIDER, options and fields...)
 /// }
@@ -419,8 +419,8 @@ pub use eventheader_macros::define_provider;
 /// to the provider with filters that include the level and keyword of the event.
 ///
 /// The `write_event!` macro returns a `u32` value with an errno result code. If no
-/// logging sessions are listening for the event, `write_event!` immediately returns 0.
-/// Otherwise, it returns the value returned by the underlying `writev` API. Since most
+/// logging sessions are listening for the event, `write_event!` immediately returns `EBADF`
+/// (9). Otherwise, it returns the value returned by the underlying `writev` API. Since most
 /// components treat logging APIs as fire-and-forget, this value should normally be ignored
 /// in production code. It is generally used only for debugging and troubleshooting.
 ///

--- a/eventheader/src/native.rs
+++ b/eventheader/src/native.rs
@@ -483,7 +483,7 @@ impl TracepointState {
         let enable_status = self.enable_status.load(Ordering::Relaxed);
         let write_index = self.write_index.load(Ordering::Relaxed);
         if enable_status == 0 || write_index > Self::HIGHEST_VALID_WRITE_INDEX {
-            return 0;
+            return 9; // linux::EBADF
         }
 
         let writev_result = self.writev(data, &write_index.to_ne_bytes());
@@ -520,7 +520,7 @@ impl TracepointState {
         let enable_status = self.enable_status.load(Ordering::Relaxed);
         let write_index = self.write_index.load(Ordering::Relaxed);
         if enable_status == 0 || write_index > Self::HIGHEST_VALID_WRITE_INDEX {
-            return 0;
+            return 9; // linux::EBADF
         }
 
         let mut extension_count = (activity_id.is_some() as u8) + ((meta_len != 0) as u8);

--- a/eventheader/tests/tests.rs
+++ b/eventheader/tests/tests.rs
@@ -254,7 +254,13 @@ fn provider_panic() {
     eh::define_provider!(PROV3, "TraceLoggingDynamicTest");
     eh::write_event!(PROV3, "Default");
     let _u = Unregister(&PROV3);
-    unsafe { PROV3.register() };
+
+    if 0 != unsafe { PROV3.register() } {
+        // If register fails (e.g. if running on downlevel kernel) then make test pass.
+        panic!("register not successful");
+    }
+
+    // Registering an already-registered provider should panic.
     unsafe { PROV3.register() };
 }
 
@@ -278,7 +284,7 @@ fn write_event() {
         "4v2o6t123c0l3k11",
         id_version(4, 2),
         opcode(6),
-        task(123), // Task is ignored by eventheader.
+        task(123),  // Task is ignored by eventheader.
         channel(0), // Channel is ignored by eventheader.
         level(3),
         keyword(0x11),

--- a/eventheader_dynamic/src/changelog.rs
+++ b/eventheader_dynamic/src/changelog.rs
@@ -3,6 +3,12 @@
 #[allow(unused_imports)]
 use crate::*; // For docs
 
+/// # v0.3.0 (2023-06-26)
+/// - If no consumers have enabled a tracepoint, the kernel now returns
+///   `EBADF`. The eventheader_dynamic crate has been updated to be
+///   consistent with the new behavior.
+pub mod v0_3_0 {}
+
 /// # v0.2.0 (2023-05-16)
 /// - Add support for macro-based logging.
 pub mod v0_2_0 {}

--- a/eventheader_macros/src/enabled_info.rs
+++ b/eventheader_macros/src/enabled_info.rs
@@ -36,10 +36,8 @@ impl EnabledInfo {
 
         // level
 
-        enabled.level = root_parser.next_tokens(
-            Required,
-            "expected constant for level, e.g. Level::Verbose",
-        );
+        enabled.level =
+            root_parser.next_tokens(Required, "expected constant for level, e.g. Level::Verbose");
 
         // keyword
 

--- a/eventheader_macros/src/event_generator.rs
+++ b/eventheader_macros/src/event_generator.rs
@@ -240,7 +240,7 @@ impl EventGenerator {
         static _EH_TRACEPOINT = EventHeaderTracepoint::new(...);
         static _EH_TRACEPOINT_PTR = &_EH_TRACEPOINT;
         if !_EH_TRACEPOINT.enabled() {
-            0u32
+            9u32 // EBADF
         } else {
             enabled_tree...
         }
@@ -369,14 +369,14 @@ impl EventGenerator {
                     .drain(),
             )
             .add_punct(";")
-            // if !_EH_TRACEPOINT.enabled() { 0u32 }
+            // if !_EH_TRACEPOINT.enabled() { 9u32 } // EBADF
             .add_ident("if")
             .add_punct("!")
             .add_ident(EH_TRACEPOINT_STATIC)
             .add_punct(".")
             .add_ident(EH_TRACEPOINT_ENABLED)
             .add_group_paren([])
-            .add_group_curly(self.tree1.add_literal(Literal::u32_suffixed(0)).drain())
+            .add_group_curly(self.tree1.add_literal(Literal::u32_suffixed(9)).drain()) // 9 = EBADF
             // else { enabled_tree... }
             .add_ident("else")
             .add_group_curly(self.enabled_tree.drain());


### PR DESCRIPTION
Linux Kernel is changing to report an EBADF error if you try to write to a tracepoint that has no listeners. Update the tracepoint library to have behavior consistent with this:

- Update comments/documentation to indicate that the caller should expect EBADF if the tracepoint is not enabled.
- In cases where we skip the writev because we know the tracepoint is disabled, we now need to return EBADF instead of 0.

Also a few fixes as suggested by new version of `cargo fmt` and `cargo clippy`.