### PR TITLE
EventBuilder - Add bookmark for struct subfield count

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto
+*.rs   text
+*.toml text

--- a/eventheader_dynamic/Cargo.toml
+++ b/eventheader_dynamic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventheader_dynamic"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"

--- a/eventheader_dynamic/src/builder.rs
+++ b/eventheader_dynamic/src/builder.rs
@@ -305,6 +305,7 @@ impl EventBuilder {
         &mut self,
         field_name: &str,
         struct_field_count: u8,
+
         field_tag: u16,
     ) -> &mut Self {
         let masked_field_count = struct_field_count & FieldFormat::ValueMask;
@@ -319,6 +320,115 @@ impl EventBuilder {
             masked_field_count,
             field_tag,
         );
+    }
+
+    /// Advanced: Adds a field containing the specified number of sub-fields, returning
+    /// a bookmark that can be used for a subsequent call to
+    /// [`EventBuilder::set_struct_field_count`]. This can be used for cases where you do
+    /// not yet know the actual number of fields that will be in the struct.
+    ///
+    /// - `field_name` should be a short and distinct string that describes the field.
+    ///
+    /// - `initial_struct_field_count` specifies your initial guess for the number of
+    ///   subsequent fields that will be considered to be part of this struct field.
+    ///   This must be in the range 1 to 127. Empty structs (structs that contain no
+    ///   fields) are not permitted.
+    ///
+    /// - `field_tag` is a 16-bit integer that will be recorded in the field and can be
+    ///   used for any provider-defined purpose. Use 0 if you are not using field tags.
+    ///
+    /// - `field_count_bookmark` receives a bookmark that can later be used in a call to
+    ///   [`EventBuilder::set_struct_field_count`].
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// // Assume some dynamic number of fields that can be enumerated but where we can't
+    /// // determine ahead of time how many fields there will be, i.e. where the
+    /// // collection of fields has `field_vals.is_empty()` and `field_vals.into_iter()`
+    /// // methods but does not have a `field_vals.len()` method.
+    /// let field_vals = [1, 2, 3];
+    ///
+    /// use eventheader_dynamic as ehd;
+    /// let mut builder = ehd::EventBuilder::new();
+    /// builder.reset("EventWithStruct", 0);
+    ///
+    /// // Structs with 0 fields are not allowed, so don't create a struct if field_vals is empty.
+    /// if !field_vals.is_empty() {
+    ///     let mut struct1_count = 0;
+    ///     let mut struct1_bookmark = 0;
+    ///
+    ///     // Add the struct, tentatively set to 1 sub-field.
+    ///     builder.add_struct_with_bookmark("struct1", 1, 0, &mut struct1_bookmark);
+    ///     for val in field_vals {
+    ///         builder.add_value("val", val, ehd::FieldFormat::Default, 0);
+    ///         struct1_count += 1;
+    ///     }
+    ///
+    ///     // Update the struct to set the actual number of sub-fields.
+    ///     builder.set_struct_field_count(struct1_bookmark, struct1_count);
+    /// }
+    /// ```
+    pub fn add_struct_with_bookmark(
+        &mut self,
+        field_name: &str,
+        initial_struct_field_count: u8,
+        field_tag: u16,
+        field_count_bookmark: &mut usize,
+    ) -> &mut Self {
+        let masked_field_count = initial_struct_field_count & FieldFormat::ValueMask;
+        debug_assert_eq!(
+            masked_field_count, initial_struct_field_count,
+            "initial_struct_field_count must be less than 128"
+        );
+        assert!(
+            masked_field_count != 0,
+            "initial_struct_field_count must not be 0"
+        );
+        self.raw_add_meta(
+            field_name,
+            FieldEncoding::Struct.as_int(),
+            masked_field_count,
+            field_tag,
+        );
+
+        *field_count_bookmark = if field_tag == 0 {
+            self.meta.len() - 1
+        } else {
+            self.meta.len() - 3
+        };
+        return self;
+    }
+
+    /// Advanced: Changes the number of sub-fields in a struct, using a bookmark
+    /// returned by [`EventBuilder::add_struct_with_bookmark`]. This can be used when you
+    /// do not know the number of fields for a struct when the struct begins, but you
+    /// determine the number of fields later.
+    ///
+    /// - `field_count_bookmark` is the value received from the call to
+    ///   [`EventBuilder::add_struct_with_bookmark`] for the struct that you are
+    ///   updating.
+    ///
+    /// - `updated_struct_field_count` is the new value to use for the struct's field
+    ///   count. This must be in the range 1 to 127. Empty structs (structs that contain
+    ///   no fields) are not permitted.
+    pub fn set_struct_field_count(
+        &mut self,
+        field_count_bookmark: usize,
+        updated_struct_field_count: u8,
+    ) -> &mut Self {
+        let masked_field_count = updated_struct_field_count & FieldFormat::ValueMask;
+        debug_assert_eq!(
+            masked_field_count, updated_struct_field_count,
+            "updated_struct_field_count must be less than 128"
+        );
+        assert!(
+            masked_field_count != 0,
+            "updated_struct_field_count must not be 0"
+        );
+        self.meta[field_count_bookmark] =
+            (self.meta[field_count_bookmark] & 0x80) | masked_field_count;
+        return self;
     }
 
     /// Adds a field containing a simple value.

--- a/eventheader_dynamic/src/changelog.rs
+++ b/eventheader_dynamic/src/changelog.rs
@@ -3,6 +3,12 @@
 #[allow(unused_imports)]
 use crate::*; // For docs
 
+/// # v0.3.3 (2023-08-08)
+/// - Add [`EventBuilder::add_struct_with_bookmark`] and
+///   [`EventBuilder::set_struct_field_count`] methods to support cases where the number
+///   of sub-fields of a struct is not known when the struct is started.
+pub mod v0_3_3 {}
+
 /// # v0.3.2 (2023-07-24)
 /// - Prefer "tracefs" over "debugfs" when searching for `user_events_data`.
 ///   (Old behavior: no preference - use whichever comes first in mount list.)

--- a/eventheader_dynamic/tests/tests.rs
+++ b/eventheader_dynamic/tests/tests.rs
@@ -127,6 +127,30 @@ fn builder() {
         .add_value("A", 65u8, FieldFormat::String8, 0)
         .write(&es_l5k1, None, None);
 
+    let vals = [1, 2, 3];
+    b.reset("bookmarks", 0);
+    if !vals.is_empty() {
+        let mut struct1_count = 0;
+        let mut struct1_bookmark = 0;
+        b.add_struct_with_bookmark("struct1", 1, 0, &mut struct1_bookmark);
+        for val in vals {
+            b.add_value("val", val, FieldFormat::Default, 0);
+            struct1_count += 1;
+        }
+        b.set_struct_field_count(struct1_bookmark, struct1_count);
+    }
+    if !vals.is_empty() {
+        let mut struct2_count = 0;
+        let mut struct2_bookmark = 0;
+        b.add_struct_with_bookmark("struct2", 1, 123, &mut struct2_bookmark);
+        for val in vals {
+            b.add_value("val", val, FieldFormat::Default, 0);
+            struct2_count += 1;
+        }
+        b.set_struct_field_count(struct2_bookmark, struct2_count);
+    }
+    b.write(&es_l5k1, None, None);
+
     validate(
         &p,
         &mut b,


### PR DESCRIPTION
Allow updating a struct's sub-field count after the struct has been started. This enables support for cases where we don't know the number of sub-fields that a struct will have at the time the struct is started, i.e. if we're adding a sub-field for each item in a collection, but the collection doesn't have a `len()` method.

Note that this does NOT enable structs with 0 sub-fields (a struct MUST have at least one sub-field and cannot have more than 127 sub-fields) and it does NOT enable adding fields out-of-order (you still need to add all the fields to the current struct before you can start a new struct).

Fixes #5.