### PR TITLE
EventBuilder - Add bookmark for struct subfield count

### DIFF
--- a/eventheader_dynamic/Cargo.toml
+++ b/eventheader_dynamic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventheader_dynamic"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"

--- a/eventheader_dynamic/src/changelog.rs
+++ b/eventheader_dynamic/src/changelog.rs
@@ -3,6 +3,12 @@
 #[allow(unused_imports)]
 use crate::*; // For docs
 
+/// # v0.3.3 (2023-08-08)
+/// - Add [`EventBuilder::add_struct_with_bookmark`] and
+///   [`EventBuilder::set_struct_field_count`] methods to support cases where the number
+///   of sub-fields of a struct is not known when the struct is started.
+pub mod v0_3_3 {}
+
 /// # v0.3.2 (2023-07-24)
 /// - Prefer "tracefs" over "debugfs" when searching for `user_events_data`.
 ///   (Old behavior: no preference - use whichever comes first in mount list.)

--- a/eventheader_dynamic/tests/tests.rs
+++ b/eventheader_dynamic/tests/tests.rs
@@ -127,6 +127,30 @@ fn builder() {
         .add_value("A", 65u8, FieldFormat::String8, 0)
         .write(&es_l5k1, None, None);
 
+    let vals = [1, 2, 3];
+    b.reset("bookmarks", 0);
+    if !vals.is_empty() {
+        let mut struct1_count = 0;
+        let mut struct1_bookmark = 0;
+        b.add_struct_with_bookmark("struct1", 1, 0, &mut struct1_bookmark);
+        for val in vals {
+            b.add_value("val", val, FieldFormat::Default, 0);
+            struct1_count += 1;
+        }
+        b.set_struct_field_count(struct1_bookmark, struct1_count);
+    }
+    if !vals.is_empty() {
+        let mut struct2_count = 0;
+        let mut struct2_bookmark = 0;
+        b.add_struct_with_bookmark("struct2", 1, 123, &mut struct2_bookmark);
+        for val in vals {
+            b.add_value("val", val, FieldFormat::Default, 0);
+            struct2_count += 1;
+        }
+        b.set_struct_field_count(struct2_bookmark, struct2_count);
+    }
+    b.write(&es_l5k1, None, None);
+
     validate(
         &p,
         &mut b,


### PR DESCRIPTION
Allow updating a struct's sub-field count after the struct has been started. This enables support for cases where we don't know the number of sub-fields that a struct will have at the time the struct is started, i.e. if we're adding a sub-field for each item in a collection, but the collection doesn't have a `len()` method.

Note that this does NOT enable structs with 0 sub-fields (a struct MUST have at least one sub-field and cannot have more than 127 sub-fields) and it does NOT enable adding fields out-of-order (you still need to add all the fields to the current struct before you can start a new struct).

Fixes #5