### PR TITLE
eventheader - check absolute paths for user_events_data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "eventheader",
     "eventheader_dynamic",

--- a/eventheader/Cargo.toml
+++ b/eventheader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventheader"
-version = "0.3.2"
+version = "0.3.4"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"

--- a/eventheader/examples/generate_events.rs
+++ b/eventheader/examples/generate_events.rs
@@ -26,9 +26,8 @@ tlg::define_provider!(
 );
 
 fn main() {
-    unsafe {
-        PROV1.register();
-    }
+    let register_errno = unsafe { PROV1.register() };
+    println!("PROV1.register() = {}", register_errno);
 
     let guid1 = tlg::Guid::from_name("H1");
     let guid2 = tlg::Guid::from_name("H2");

--- a/eventheader/src/changelog.rs
+++ b/eventheader/src/changelog.rs
@@ -3,6 +3,15 @@
 #[allow(unused_imports)]
 use crate::*; // For docs
 
+/// # v0.3.4 (TBD)
+/// - Changed procedure for locating the `user_events_data` file.
+///   - Old: parse `/proc/mounts` to determine the `tracefs` or `debugfs` mount
+///     point, then use that as the root for the `user_events_data` path.
+///   - New: try `/sys/kernel/tracing/user_events_data`, then try
+///     `/sys/kernel/debug/tracing/user_events_data`, and then parse `/proc/mounts`
+///     (i.e. only parse `/proc/mounts` if the absolute paths don't exist)
+pub mod v0_3_4 {}
+
 /// # v0.3.2 (2023-07-24)
 /// - Prefer "tracefs" over "debugfs" when searching for `user_events_data`.
 ///   (Old behavior: no preference - use whichever comes first in mount list.)

--- a/eventheader/src/changelog.rs
+++ b/eventheader/src/changelog.rs
@@ -7,9 +7,13 @@ use crate::*; // For docs
 /// - Changed procedure for locating the `user_events_data` file.
 ///   - Old: parse `/proc/mounts` to determine the `tracefs` or `debugfs` mount
 ///     point, then use that as the root for the `user_events_data` path.
-///   - New: try `/sys/kernel/tracing/user_events_data`, then try
-///     `/sys/kernel/debug/tracing/user_events_data`, and then parse `/proc/mounts`
-///     (i.e. only parse `/proc/mounts` if the absolute paths don't exist)
+///   - New: try `/sys/kernel/tracing/user_events_data`, then parse `/proc/mounts`
+///     to find the tracefs mount point (i.e. only parse `/proc/mounts` if the
+///     absolute path doesn't exist, and only look for tracefs, not debugfs).
+///   - Rationale: If `debugfs` is mounted then `tracefs` is always also mounted,
+///     so we don't ever need to look for `debugfs`. Probe the absolute path so
+///     that containers don't have to create a fake `/proc/mounts` and for startup
+///     efficiency.
 pub mod v0_3_4 {}
 
 /// # v0.3.2 (2023-07-24)

--- a/eventheader/src/changelog.rs
+++ b/eventheader/src/changelog.rs
@@ -7,13 +7,10 @@ use crate::*; // For docs
 /// - Changed procedure for locating the `user_events_data` file.
 ///   - Old: parse `/proc/mounts` to determine the `tracefs` or `debugfs` mount
 ///     point, then use that as the root for the `user_events_data` path.
-///   - New: try `/sys/kernel/tracing/user_events_data`, then parse `/proc/mounts`
-///     to find the tracefs mount point (i.e. only parse `/proc/mounts` if the
-///     absolute path doesn't exist, and only look for tracefs, not debugfs).
-///   - Rationale: If `debugfs` is mounted then `tracefs` is always also mounted,
-///     so we don't ever need to look for `debugfs`. Probe the absolute path so
-///     that containers don't have to create a fake `/proc/mounts` and for startup
-///     efficiency.
+///   - New: try `/sys/kernel/tracing/user_events_data`; if that doesn't exist,
+///     parse `/proc/mounts` to find the `tracefs` or `debugfs` mount point.
+///   - Rationale: Probe an absolute path so that containers don't have to
+///     create a fake `/proc/mounts` and for efficiency.
 pub mod v0_3_4 {}
 
 /// # v0.3.2 (2023-07-24)

--- a/eventheader/src/native.rs
+++ b/eventheader/src/native.rs
@@ -94,13 +94,15 @@ impl UserEventsDataFile {
         }
         #[cfg(all(target_os = "linux", feature = "user_events"))]
         {
-            // Need to find the ".../tracing/user_events_data" file in tracefs.
+            // Need to find the ".../tracing/user_events_data" file in tracefs or debugfs.
 
             // First, try the usual tracefs mount point.
             if let new_file @ 0.. = open_rdwr(b"/sys/kernel/tracing/user_events_data\0") {
                 new_file_or_error = new_file;
             } else {
-                // Determine tracefs mount point by parsing "/proc/mounts".
+                // Determine tracefs/debugfs mount point by parsing "/proc/mounts".
+                // Prefer "tracefs" over "debugfs": if we find a debugfs, save the path but
+                // keep looking in case we find a tracefs later.
                 clear_errno();
                 let mounts_file = unsafe {
                     linux::fopen(
@@ -165,23 +167,34 @@ impl UserEventsDataFile {
                             continue;
                         }
 
+                        let path_suffix: &[u8]; // Includes NUL
                         let fs = &line[fs_begin..fs_end];
-                        if fs != b"tracefs" {
+                        let keep_looking;
+                        if fs == b"tracefs" {
+                            // "tracefsMountPoint/user_events_data"
+                            path_suffix = b"/user_events_data\0";
+                            keep_looking = false; // prefer "tracefs" over "debugfs"
+                        } else if path[0] == 0 && fs == b"debugfs" {
+                            // "debugfsMountPoint/tracing/user_events_data"
+                            path_suffix = b"/tracing/user_events_data\0";
+                            keep_looking = true; // prefer "tracefs" over "debugfs"
+                        } else {
                             continue;
                         }
 
-                        const PATH_SUFFIX: &[u8] = b"/user_events_data\0"; // Includes NUL
                         let mount_len = mount_end - mount_begin;
-                        let path_len = mount_len + PATH_SUFFIX.len(); // Includes NUL
+                        let path_len = mount_len + path_suffix.len(); // Includes NUL
                         if path_len > path.len() {
                             continue;
                         }
 
                         // path = mountpoint + suffix
                         path[0..mount_len].copy_from_slice(&line[mount_begin..mount_end]);
-                        path[mount_len..path_len].copy_from_slice(PATH_SUFFIX); // Includes NUL
+                        path[mount_len..path_len].copy_from_slice(path_suffix); // Includes NUL
 
-                        break;
+                        if !keep_looking {
+                            break;
+                        }
                     }
 
                     unsafe { linux::fclose(mounts_file) };

--- a/eventheader_dynamic/Cargo.toml
+++ b/eventheader_dynamic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventheader_dynamic"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"
@@ -28,7 +28,7 @@ default = ["user_events"]
 user_events = ["eventheader/user_events"] # Logging is enabled if Linux && user_events.
 
 [dependencies]
-eventheader = { default-features = false, version = "= 0.3.2", path = "../eventheader" }
+eventheader = { default-features = false, version = "= 0.3.4", path = "../eventheader" }
 
 [dev-dependencies]
 uuid  = ">= 1.1"

--- a/eventheader_dynamic/src/changelog.rs
+++ b/eventheader_dynamic/src/changelog.rs
@@ -7,9 +7,13 @@ use crate::*; // For docs
 /// - Changed procedure for locating the `user_events_data` file.
 ///   - Old: parse `/proc/mounts` to determine the `tracefs` or `debugfs` mount
 ///     point, then use that as the root for the `user_events_data` path.
-///   - New: try `/sys/kernel/tracing/user_events_data`, then try
-///     `/sys/kernel/debug/tracing/user_events_data`, and then parse `/proc/mounts`
-///     (i.e. only parse `/proc/mounts` if the absolute paths don't exist)
+///   - New: try `/sys/kernel/tracing/user_events_data`, then parse `/proc/mounts`
+///     to find the tracefs mount point (i.e. only parse `/proc/mounts` if the
+///     absolute path doesn't exist, and only look for tracefs, not debugfs).
+///   - Rationale: If `debugfs` is mounted then `tracefs` is always also mounted,
+///     so we don't ever need to look for `debugfs`. Probe the absolute path so
+///     that containers don't have to create a fake `/proc/mounts` and for startup
+///     efficiency.
 pub mod v0_3_4 {}
 
 /// # v0.3.3 (2023-08-08)

--- a/eventheader_dynamic/src/changelog.rs
+++ b/eventheader_dynamic/src/changelog.rs
@@ -7,13 +7,10 @@ use crate::*; // For docs
 /// - Changed procedure for locating the `user_events_data` file.
 ///   - Old: parse `/proc/mounts` to determine the `tracefs` or `debugfs` mount
 ///     point, then use that as the root for the `user_events_data` path.
-///   - New: try `/sys/kernel/tracing/user_events_data`, then parse `/proc/mounts`
-///     to find the tracefs mount point (i.e. only parse `/proc/mounts` if the
-///     absolute path doesn't exist, and only look for tracefs, not debugfs).
-///   - Rationale: If `debugfs` is mounted then `tracefs` is always also mounted,
-///     so we don't ever need to look for `debugfs`. Probe the absolute path so
-///     that containers don't have to create a fake `/proc/mounts` and for startup
-///     efficiency.
+///   - New: try `/sys/kernel/tracing/user_events_data`; if that doesn't exist,
+///     parse `/proc/mounts` to find the `tracefs` or `debugfs` mount point.
+///   - Rationale: Probe an absolute path so that containers don't have to
+///     create a fake `/proc/mounts` and for efficiency.
 pub mod v0_3_4 {}
 
 /// # v0.3.3 (2023-08-08)

--- a/eventheader_dynamic/src/changelog.rs
+++ b/eventheader_dynamic/src/changelog.rs
@@ -3,6 +3,15 @@
 #[allow(unused_imports)]
 use crate::*; // For docs
 
+/// # v0.3.4 (TBD)
+/// - Changed procedure for locating the `user_events_data` file.
+///   - Old: parse `/proc/mounts` to determine the `tracefs` or `debugfs` mount
+///     point, then use that as the root for the `user_events_data` path.
+///   - New: try `/sys/kernel/tracing/user_events_data`, then try
+///     `/sys/kernel/debug/tracing/user_events_data`, and then parse `/proc/mounts`
+///     (i.e. only parse `/proc/mounts` if the absolute paths don't exist)
+pub mod v0_3_4 {}
+
 /// # v0.3.3 (2023-08-08)
 /// - Add [`EventBuilder::add_struct_with_bookmark`] and
 ///   [`EventBuilder::set_struct_field_count`] methods to support cases where the number


### PR DESCRIPTION
Previously, the trace provider initialization code located the user_events_data file by parsing `/proc/mounts` to find the tracefs or debugfs mount point, then used the mount point to form the full path.

This works fairly well, but it is an obstacle for container scenarios - the container creator probably doesn't want to mount the `tracefs` or `debugfs` filesystem into the container, but they have to fake it by having a `/proc/mounts` file that points at a fake tracing directory.

Fix by looking for absolute path `/sys/kernel/tracing/user_events_data` before trying to parse `/proc/mounts`. This means a container creator only has to project a `user_events_data` file and doesn't have to create a dummy `/proc/mounts` file. It will also tend to be more efficient for non-container scenarios where the `user_events_data` file is present (if present, it will almost always be the probed path). The downside is that in cases where it isn't present, we now probe one additional location before giving up.