### PR TITLE
Open user_events_data for WRONLY instead of RDWR

### DIFF
--- a/eventheader/Cargo.toml
+++ b/eventheader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventheader"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"

--- a/eventheader/src/changelog.rs
+++ b/eventheader/src/changelog.rs
@@ -3,6 +3,10 @@
 #[allow(unused_imports)]
 use crate::*; // For docs
 
+/// # v0.3.5 (2023-02-27)
+/// - Open `user_events_data` for WRONLY instead of RDWR.
+pub mod v0_3_5 {}
+
 /// # v0.3.4 (2023-11-27)
 /// - Changed procedure for locating the `user_events_data` file.
 ///   - Old: parse `/proc/mounts` to determine the `tracefs` or `debugfs` mount

--- a/eventheader/src/lib.rs
+++ b/eventheader/src/lib.rs
@@ -31,10 +31,12 @@
 //!   the following line to your `/etc/fstab` file:
 //!   `tracefs /sys/kernel/tracing tracefs defaults 0 0`
 //! - The user that will generate events must have `x` access to the `tracing`
-//!   directory, e.g. `chmod a+x /sys/kernel/tracing`
-//! - The user that will generate events must have `rw` access to the
-//!   `tracing/user_events_data` file, e.g.
-//!   `chmod a+rw /sys/kernel/tracing/user_events_data`
+//!   directory and `w` access to the `tracing/user_events_data` file. One
+//!   possible implementation is to create a `tracers` group, then:
+//!   - `chgrp tracers /sys/kernel/tracing`
+//!   - `chgrp tracers /sys/kernel/tracing/user_events_data`
+//!   - `chmod g+x /sys/kernel/tracing`
+//!   - `chmod g+w /sys/kernel/tracing/user_events_data`
 //! - Collect traces using a tool like
 //!   [`perf`](https://perf.wiki.kernel.org/index.php).
 //! - Decode traces using a tool like

--- a/eventheader/src/native.rs
+++ b/eventheader/src/native.rs
@@ -39,11 +39,11 @@ fn clear_errno() {
     unsafe { *linux::__errno_location() = 0 };
 }
 
-/// linux::open(path0, O_RDWR)
+/// linux::open(path0, O_WRONLY)
 #[cfg(all(target_os = "linux", feature = "user_events"))]
-fn open_rdwr(path0: &[u8]) -> ffi::c_int {
+fn open_wronly(path0: &[u8]) -> ffi::c_int {
     assert!(path0.ends_with(&[0]));
-    return unsafe { linux::open(path0.as_ptr().cast::<ffi::c_char>(), linux::O_RDWR) };
+    return unsafe { linux::open(path0.as_ptr().cast::<ffi::c_char>(), linux::O_WRONLY) };
 }
 
 /// Copies the specified value to the specified location.
@@ -97,7 +97,7 @@ impl UserEventsDataFile {
             // Need to find the ".../tracing/user_events_data" file in tracefs or debugfs.
 
             // First, try the usual tracefs mount point.
-            if let new_file @ 0.. = open_rdwr(b"/sys/kernel/tracing/user_events_data\0") {
+            if let new_file @ 0.. = open_wronly(b"/sys/kernel/tracing/user_events_data\0") {
                 new_file_or_error = new_file;
             } else {
                 // Determine tracefs/debugfs mount point by parsing "/proc/mounts".
@@ -205,7 +205,7 @@ impl UserEventsDataFile {
                         // path is now something like "/sys/kernel/tracing/user_events_data\0" or
                         // "/sys/kernel/debug/tracing/user_events_data\0".
                         clear_errno();
-                        new_file_or_error = if let new_file @ 0.. = open_rdwr(&path) {
+                        new_file_or_error = if let new_file @ 0.. = open_wronly(&path) {
                             new_file
                         } else {
                             -get_failure_errno()

--- a/eventheader_dynamic/Cargo.toml
+++ b/eventheader_dynamic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventheader_dynamic"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"
@@ -28,7 +28,7 @@ default = ["user_events"]
 user_events = ["eventheader/user_events"] # Logging is enabled if Linux && user_events.
 
 [dependencies]
-eventheader = { default-features = false, version = "= 0.3.4", path = "../eventheader" }
+eventheader = { default-features = false, version = "= 0.3.5", path = "../eventheader" }
 
 [dev-dependencies]
 uuid  = ">= 1.1"

--- a/eventheader_dynamic/src/changelog.rs
+++ b/eventheader_dynamic/src/changelog.rs
@@ -3,6 +3,10 @@
 #[allow(unused_imports)]
 use crate::*; // For docs
 
+/// # v0.3.5 (2023-02-27)
+/// - Open `user_events_data` for WRONLY instead of RDWR.
+pub mod v0_3_5 {}
+
 /// # v0.3.4 (2023-11-27)
 /// - Changed procedure for locating the `user_events_data` file.
 ///   - Old: parse `/proc/mounts` to determine the `tracefs` or `debugfs` mount


### PR DESCRIPTION
Minimize permissions needed on the user_events_data file: we were opening it for RDWR, but we only need to write, so fix by opening it for WRONLY.