### PR TITLE
Create tracepoint crate with low-level API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "tracepoint",
     "eventheader",
     "eventheader_dynamic",
     "eventheader_macros",

--- a/eventheader/Cargo.toml
+++ b/eventheader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eventheader"
-version = "0.3.5"
+version = "0.4.0"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"
@@ -25,14 +25,12 @@ rust-version = "1.63"
 
 [features]
 default = ["user_events", "macros"]
-user_events = [] # Logging is enabled if linux && user_events.
+user_events = ["tracepoint/user_events"] # Logging is enabled if linux && user_events.
 macros = ["dep:eventheader_macros"]
 
 [dependencies]
+tracepoint = { default-features = false, version = "= 0.4.0", path = "../tracepoint" }
 eventheader_macros = { optional = true, version = "= 0.3.0", path = "../eventheader_macros" }
-
-[target.'cfg(target_os = "linux")'.dependencies]
-libc = { default-features = false, version = "0.2" }
 
 [dev-dependencies]
 uuid  = ">= 1.1"

--- a/eventheader/src/changelog.rs
+++ b/eventheader/src/changelog.rs
@@ -1,7 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 //! Release history
 
 #[allow(unused_imports)]
 use crate::*; // For docs
+
+/// # v0.4.0 (TBD)
+/// - Move non-eventheader code into separate `tracepoint` crate.
+pub mod v0_4_0 {}
 
 /// # v0.3.5 (2023-02-27)
 /// - Open `user_events_data` for WRONLY instead of RDWR.

--- a/eventheader/src/descriptors.rs
+++ b/eventheader/src/descriptors.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-use core::marker::PhantomData;
-use core::mem;
-
 use crate::enums::ExtensionKind;
 use crate::enums::HeaderFlags;
 use crate::enums::Level;
@@ -145,121 +142,6 @@ impl EventHeaderExtension {
             } else {
                 kind
             },
-        };
-    }
-}
-
-/// Describes a block of data to be sent to user_events via writev.
-///
-/// Note: This must have the same underlying representation as `struct iovec`.
-#[repr(C)]
-#[derive(Debug, Default)]
-pub struct EventDataDescriptor<'a> {
-    ptr: usize,
-    size: usize,
-    lifetime: PhantomData<&'a [u8]>,
-}
-
-impl<'a> EventDataDescriptor<'a> {
-    /// Returns an EventDataDescriptor initialized with { null, 0 }.
-    pub const fn zero() -> Self {
-        return Self {
-            ptr: 0,
-            size: 0,
-            lifetime: PhantomData,
-        };
-    }
-
-    /// Returns true if this descriptor's size is 0.
-    pub const fn is_empty(&self) -> bool {
-        return self.size == 0;
-    }
-
-    /// Returns an EventDataDescriptor initialized with the specified ptr and size.
-    ///
-    /// # Safety
-    ///
-    /// This bypasses lifetime tracking. Caller must ensure that this
-    /// EventDataDescriptor is not used after the referenced data's lifetime.
-    /// Typically, this is done by overwriting the descriptor with
-    /// [`EventDataDescriptor::zero`] after it has been used.
-    pub const unsafe fn from_raw_ptr(ptr: usize, size: usize) -> Self {
-        return Self {
-            ptr,
-            size,
-            lifetime: PhantomData,
-        };
-    }
-
-    /// Returns an EventDataDescriptor initialized with the specified slice's bytes.
-    pub fn from_bytes(value: &'a [u8]) -> Self {
-        return Self {
-            ptr: value.as_ptr() as usize,
-            size: value.len(),
-            lifetime: PhantomData,
-        };
-    }
-
-    /// Returns an EventDataDescriptor initialized with the specified value's bytes.
-    pub fn from_value<T: Copy>(value: &'a T) -> Self {
-        return Self {
-            ptr: value as *const T as usize,
-            size: mem::size_of::<T>(),
-            lifetime: PhantomData,
-        };
-    }
-
-    /// Returns an EventDataDescriptor for a nul-terminated string.
-    /// Returned descriptor does NOT include the nul-termination.
-    ///
-    /// Resulting descriptor's size is the minimum of:
-    /// - `size_of::<T>() * 65535`
-    /// - `size_of::<T>() * value.len()`
-    /// - `size_of::<T>() * (index of first element equal to T::default())`
-    pub fn from_cstr<T: Copy + Default + Eq>(mut value: &'a [T]) -> Self {
-        let mut value_len = value.len();
-
-        const MAX_LEN: usize = 65535;
-        if value_len > MAX_LEN {
-            value = &value[..MAX_LEN];
-            value_len = value.len();
-        }
-
-        let zero = T::default();
-        let mut len = 0;
-        while len < value_len {
-            if value[len] == zero {
-                value = &value[..len];
-                break;
-            }
-
-            len += 1;
-        }
-
-        return Self {
-            ptr: value.as_ptr() as usize,
-            size: mem::size_of_val(value),
-            lifetime: PhantomData,
-        };
-    }
-
-    /// Returns an EventDataDescriptor for variable-length array field.
-    ///
-    /// Resulting descriptor's size is the minimum of:
-    /// - `size_of::<T>() * 65535`
-    /// - `size_of::<T>() * value.len()`
-    pub fn from_slice<T: Copy>(mut value: &'a [T]) -> Self {
-        let value_len = value.len();
-
-        const MAX_LEN: usize = 65535;
-        if MAX_LEN < value_len {
-            value = &value[..MAX_LEN];
-        }
-
-        return Self {
-            ptr: value.as_ptr() as usize,
-            size: mem::size_of_val(value),
-            lifetime: PhantomData,
         };
     }
 }

--- a/eventheader/src/lib.rs
+++ b/eventheader/src/lib.rs
@@ -1003,13 +1003,16 @@ pub use eventheader_macros::write_event;
 #[cfg(feature = "macros")]
 pub use eventheader_macros::provider_enabled;
 
+// Re-exports from tracepoint:
+pub use tracepoint::NativeImplementation;
+pub use tracepoint::NATIVE_IMPLEMENTATION;
+
+// Exports from eventheader:
 pub use enums::FieldEncoding;
 pub use enums::FieldFormat;
 pub use enums::Level;
 pub use enums::Opcode;
 pub use guid::Guid;
-pub use native::NativeImplementation;
-pub use native::NATIVE_IMPLEMENTATION;
 pub use provider::Provider;
 pub mod _internal;
 pub mod changelog;
@@ -1048,5 +1051,4 @@ macro_rules! time_from_systemtime {
 mod descriptors;
 mod enums;
 mod guid;
-mod native;
 mod provider;

--- a/eventheader/src/provider.rs
+++ b/eventheader/src/provider.rs
@@ -10,11 +10,11 @@ use core::ptr;
 use core::str;
 use core::sync::atomic;
 
+use tracepoint::EventDataDescriptor;
+
 use crate::Level;
 use crate::_internal;
-use crate::descriptors::EventDataDescriptor;
 use crate::descriptors::EventHeader;
-use crate::native;
 
 #[allow(unused_imports)] // For docs
 #[cfg(feature = "macros")]
@@ -257,7 +257,7 @@ pub const unsafe fn provider_new<'a>(
 
 /// Stores the information needed for registering and managing a tracepoint.
 pub struct EventHeaderTracepoint<'a> {
-    state: native::TracepointState,
+    state: _internal::TracepointState,
     header: EventHeader,
     keyword: u64,
     metadata: &'a [u8],
@@ -267,7 +267,7 @@ impl<'a> EventHeaderTracepoint<'a> {
     /// Sets up the data for managing a tracepoint.
     pub const fn new(header: EventHeader, keyword: u64, metadata: &'a [u8]) -> Self {
         return Self {
-            state: native::TracepointState::new(0),
+            state: _internal::TracepointState::new(0),
             header,
             keyword,
             metadata,
@@ -301,7 +301,8 @@ impl<'a> EventHeaderTracepoint<'a> {
     {
         debug_assert!(data[1].is_empty());
         data[1] = EventDataDescriptor::<'a>::from_bytes(self.metadata);
-        return self.state.write_eventheader(
+        return _internal::write_eventheader(
+            &self.state,
             &self.header,
             activity_id,
             related_id,

--- a/eventheader_dynamic/src/builder.rs
+++ b/eventheader_dynamic/src/builder.rs
@@ -8,6 +8,7 @@ use core::ptr::copy_nonoverlapping;
 use eventheader::FieldEncoding;
 use eventheader::FieldFormat;
 use eventheader::Opcode;
+use eventheader::_internal;
 use eventheader::_internal::EventDataDescriptor;
 use eventheader::_internal::EventHeader;
 use eventheader::_internal::HeaderFlags;
@@ -226,7 +227,8 @@ impl EventBuilder {
         return if self.meta.len() + self.data.len() > 65535 - (52 + 16) {
             34 // libc::ERANGE
         } else {
-            event_set.state().write_eventheader(
+            _internal::write_eventheader(
+                event_set.state(),
                 &EventHeader {
                     flags: self.flags,
                     version: self.version,

--- a/eventheader_dynamic/src/changelog.rs
+++ b/eventheader_dynamic/src/changelog.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 //! Release history
 
 #[allow(unused_imports)]

--- a/eventheader_macros/src/enabled_generator.rs
+++ b/eventheader_macros/src/enabled_generator.rs
@@ -71,9 +71,10 @@ impl EnabledGenerator {
                         self.tree2
                             .add_punct("&")
                             .push_span(provider_symbol_span)
-                            .add_ident(&String::from_iter(
-                                [PROVIDER_PTR_VAR_PREFIX, &provider_symbol_string].into_iter(),
-                            ))
+                            .add_ident(&String::from_iter([
+                                PROVIDER_PTR_VAR_PREFIX,
+                                &provider_symbol_string,
+                            ]))
                             .pop_span()
                             .drain(),
                     )
@@ -122,9 +123,10 @@ impl EnabledGenerator {
                 self.tree1
                     .add_ident("link_section")
                     .add_punct("=")
-                    .add_literal(Literal::string(&String::from_iter(
-                        [TRACEPOINTS_SECTION_PREFIX, &provider_symbol_string].into_iter(),
-                    )))
+                    .add_literal(Literal::string(&String::from_iter([
+                        TRACEPOINTS_SECTION_PREFIX,
+                        &provider_symbol_string,
+                    ])))
                     .drain(),
             )
             // static mut _EH_TRACEPOINT_PTR: *const ehi::EventHeaderTracepoint = &_EH_TRACEPOINT;

--- a/eventheader_macros/src/event_generator.rs
+++ b/eventheader_macros/src/event_generator.rs
@@ -159,9 +159,10 @@ impl EventGenerator {
                 self.tree1
                     .add_ident("link_section")
                     .add_punct("=")
-                    .add_literal(Literal::string(&String::from_iter(
-                        [TRACEPOINTS_SECTION_PREFIX, &provider_symbol_string].into_iter(),
-                    )))
+                    .add_literal(Literal::string(&String::from_iter([
+                        TRACEPOINTS_SECTION_PREFIX,
+                        &provider_symbol_string,
+                    ])))
                     .drain(),
             )
             // static mut _EH_TRACEPOINT_PTR: *const ehi::EventHeaderTracepoint = &_EH_TRACEPOINT;
@@ -324,9 +325,10 @@ impl EventGenerator {
                         self.tree2
                             .add_punct("&")
                             .push_span(provider_symbol_span)
-                            .add_ident(&String::from_iter(
-                                [PROVIDER_PTR_VAR_PREFIX, &provider_symbol_string].into_iter(),
-                            ))
+                            .add_ident(&String::from_iter([
+                                PROVIDER_PTR_VAR_PREFIX,
+                                &provider_symbol_string,
+                            ]))
                             .pop_span()
                             .drain(),
                     )

--- a/eventheader_macros/src/provider_generator.rs
+++ b/eventheader_macros/src/provider_generator.rs
@@ -27,16 +27,16 @@ impl ProviderGenerator {
 
         // __start__eh_tracepoints_MY_PROVIDER
         let provider_section_start =
-            String::from_iter([TRACEPOINTS_SECTION_START_PREFIX, &provider_sym].into_iter());
+            String::from_iter([TRACEPOINTS_SECTION_START_PREFIX, &provider_sym]);
 
         // __stop__eh_tracepoints_MY_PROVIDER
         let provider_section_stop =
-            String::from_iter([TRACEPOINTS_SECTION_STOP_PREFIX, &provider_sym].into_iter());
+            String::from_iter([TRACEPOINTS_SECTION_STOP_PREFIX, &provider_sym]);
 
         let options = if provider.group_name.is_empty() {
             String::new()
         } else {
-            String::from_iter(["G", &provider.group_name].into_iter())
+            String::from_iter(["G", &provider.group_name])
         };
 
         let prov_tokens = self
@@ -119,9 +119,10 @@ impl ProviderGenerator {
                 self.tree1
                     .add_ident("link_section")
                     .add_punct("=")
-                    .add_literal(Literal::string(&String::from_iter(
-                        [TRACEPOINTS_SECTION_PREFIX, &provider_sym].into_iter(),
-                    )))
+                    .add_literal(Literal::string(&String::from_iter([
+                        TRACEPOINTS_SECTION_PREFIX,
+                        &provider_sym,
+                    ])))
                     .drain(),
             )
             // #[no_mangle]
@@ -130,9 +131,7 @@ impl ProviderGenerator {
             // static mut _eh_define_provider_MY_PROVIDER: *const usize = ::core::ptr::null();
             .add_ident("static")
             .add_ident("mut")
-            .add_ident(&String::from_iter(
-                [PROVIDER_PTR_VAR_PREFIX, &provider_sym].into_iter(),
-            ))
+            .add_ident(&String::from_iter([PROVIDER_PTR_VAR_PREFIX, &provider_sym]))
             .add_punct(":")
             .add_punct("*")
             .add_ident("const")

--- a/eventheader_macros/src/tree.rs
+++ b/eventheader_macros/src/tree.rs
@@ -218,24 +218,18 @@ impl Tree {
         return self
             // #[cfg(target_os = "linux")]
             .add_punct("#")
-            .add_group_square(
-                [
-                    Ident::new("cfg", span).into(),
-                    Group::new(
-                        Delimiter::Parenthesis,
-                        TokenStream::from_iter(
-                            [
-                                TokenTree::from(Ident::new("target_os", span)),
-                                TokenTree::from(Punct::new('=', Spacing::Alone)),
-                                TokenTree::from(Literal::string("linux")),
-                            ]
-                            .into_iter(),
-                        ),
-                    )
-                    .into(),
-                ]
-                .into_iter(),
-            );
+            .add_group_square([
+                Ident::new("cfg", span).into(),
+                Group::new(
+                    Delimiter::Parenthesis,
+                    TokenStream::from_iter([
+                        TokenTree::from(Ident::new("target_os", span)),
+                        TokenTree::from(Punct::new('=', Spacing::Alone)),
+                        TokenTree::from(Literal::string("linux")),
+                    ]),
+                )
+                .into(),
+            ]);
     }
 
     pub fn add_cfg_not_linux(&mut self) -> &mut Self {
@@ -243,33 +237,24 @@ impl Tree {
         return self
             // #[cfg(not(target_os = "linux"))]
             .add_punct("#")
-            .add_group_square(
-                [
-                    Ident::new("cfg", span).into(),
-                    Group::new(
-                        Delimiter::Parenthesis,
-                        TokenStream::from_iter(
-                            [
-                                TokenTree::from(Ident::new("not", span)),
-                                Group::new(
-                                    Delimiter::Parenthesis,
-                                    TokenStream::from_iter(
-                                        [
-                                            TokenTree::from(Ident::new("target_os", span)),
-                                            TokenTree::from(Punct::new('=', Spacing::Alone)),
-                                            TokenTree::from(Literal::string("linux")),
-                                        ]
-                                        .into_iter(),
-                                    ),
-                                )
-                                .into(),
-                            ]
-                            .into_iter(),
-                        ),
-                    )
-                    .into(),
-                ]
-                .into_iter(),
-            );
+            .add_group_square([
+                Ident::new("cfg", span).into(),
+                Group::new(
+                    Delimiter::Parenthesis,
+                    TokenStream::from_iter([
+                        TokenTree::from(Ident::new("not", span)),
+                        Group::new(
+                            Delimiter::Parenthesis,
+                            TokenStream::from_iter([
+                                TokenTree::from(Ident::new("target_os", span)),
+                                TokenTree::from(Punct::new('=', Spacing::Alone)),
+                                TokenTree::from(Literal::string("linux")),
+                            ]),
+                        )
+                        .into(),
+                    ]),
+                )
+                .into(),
+            ]);
     }
 }

--- a/tracepoint/Cargo.toml
+++ b/tracepoint/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
-name = "eventheader_dynamic"
+name = "tracepoint"
 version = "0.4.0"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT"
-description = "Rust API for runtime-specified eventheader-encoded Linux Tracepoints via user_events"
+description = "Rust API for Linux Tracepoints via user_events"
 keywords = [
     "user_events",
-    "eventheader",
     "tracepoints",
     "trace",
     "logging",
@@ -25,10 +24,7 @@ rust-version = "1.63"
 
 [features]
 default = ["user_events"]
-user_events = ["eventheader/user_events"] # Logging is enabled if Linux && user_events.
+user_events = [] # Logging is enabled if linux && user_events.
 
-[dependencies]
-eventheader = { default-features = false, version = "= 0.4.0", path = "../eventheader" }
-
-[dev-dependencies]
-uuid  = ">= 1.1"
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = { default-features = false, version = "0.2" }

--- a/tracepoint/README.md
+++ b/tracepoint/README.md
@@ -1,0 +1,19 @@
+# Low-level support for Linux Tracepoints
+
+[![MIT licensed][mit-badge]][mit-url]
+[![Build Status][actions-badge]][actions-url]
+![maintenance status][maint-badge]
+
+[mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
+[mit-url]: https://github.com/microsoft/LinuxTracepoints-Rust/blob/main/LICENSE
+[actions-badge]: https://github.com/microsoft/LinuxTracepoints-Rust/actions/workflows/Rust.yml/badge.svg
+[actions-url]: https://github.com/microsoft/LinuxTracepoints-Rust/actions/workflows/Rust.yml
+[maint-badge]: https://img.shields.io/badge/maintenance-experimental-blue.svg
+
+The `tracepoint` crate provides low-level building blocks for logging
+[Tracepoints](https://www.kernel.org/doc/html/latest/trace/tracepoints.html)
+via the Linux [user_events](https://docs.kernel.org/trace/user_events.html)
+system. The events can be generated and collected on Linux 6.4 or later
+(requires the `user_events` kernel feature to be enabled, the `tracefs` or
+`debugfs` filesystem to be mounted, and appropriate permissions configured for
+the `/sys/kernel/.../tracing/user_events_data` file).

--- a/tracepoint/src/changelog.rs
+++ b/tracepoint/src/changelog.rs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+//! Release history
+
+#[allow(unused_imports)]
+use crate::*; // For docs
+
+/// # v0.4.0 (TBD)
+/// - Create tracepoint crate with low-level user_events API.
+pub mod v0_4_0 {}

--- a/tracepoint/src/descriptors.rs
+++ b/tracepoint/src/descriptors.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#[allow(unused_imports)]
+use crate::native::TracepointState; // For docs
+
+use core::marker::PhantomData;
+use core::mem;
+
+/// Low-level API: Describes a block of data to be sent to user_events via
+/// [`TracepointState::write`].
+///
+/// Note: This must have the same underlying representation as `struct iovec`.
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct EventDataDescriptor<'a> {
+    ptr: usize,
+    size: usize,
+    lifetime: PhantomData<&'a [u8]>,
+}
+
+impl<'a> EventDataDescriptor<'a> {
+    /// Returns an EventDataDescriptor initialized with { null, 0 }.
+    pub const fn zero() -> Self {
+        return Self {
+            ptr: 0,
+            size: 0,
+            lifetime: PhantomData,
+        };
+    }
+
+    /// Returns true if this descriptor's size is 0.
+    pub const fn is_empty(&self) -> bool {
+        return self.size == 0;
+    }
+
+    /// Returns an EventDataDescriptor initialized with the specified ptr and size.
+    ///
+    /// # Safety
+    ///
+    /// This bypasses lifetime tracking. Caller must ensure that this
+    /// EventDataDescriptor is not used after the referenced data's lifetime.
+    /// Typically, this is done by overwriting the descriptor with
+    /// [`EventDataDescriptor::zero`] after it has been used.
+    pub const unsafe fn from_raw_ptr(ptr: usize, size: usize) -> Self {
+        return Self {
+            ptr,
+            size,
+            lifetime: PhantomData,
+        };
+    }
+
+    /// Returns an EventDataDescriptor initialized with the specified slice's bytes.
+    pub fn from_bytes(value: &'a [u8]) -> Self {
+        return Self {
+            ptr: value.as_ptr() as usize,
+            size: value.len(),
+            lifetime: PhantomData,
+        };
+    }
+
+    /// Returns an EventDataDescriptor initialized with the specified value's bytes.
+    pub fn from_value<T: Copy>(value: &'a T) -> Self {
+        return Self {
+            ptr: value as *const T as usize,
+            size: mem::size_of::<T>(),
+            lifetime: PhantomData,
+        };
+    }
+
+    /// Returns an EventDataDescriptor for a nul-terminated string.
+    /// Returned descriptor does NOT include the nul-termination.
+    ///
+    /// Resulting descriptor's size is the minimum of:
+    /// - `size_of::<T>() * 65535`
+    /// - `size_of::<T>() * value.len()`
+    /// - `size_of::<T>() * (index of first element equal to T::default())`
+    pub fn from_cstr<T: Copy + Default + Eq>(mut value: &'a [T]) -> Self {
+        let mut value_len = value.len();
+
+        const MAX_LEN: usize = 65535;
+        if value_len > MAX_LEN {
+            value = &value[..MAX_LEN];
+            value_len = value.len();
+        }
+
+        let zero = T::default();
+        let mut len = 0;
+        while len < value_len {
+            if value[len] == zero {
+                value = &value[..len];
+                break;
+            }
+
+            len += 1;
+        }
+
+        return Self {
+            ptr: value.as_ptr() as usize,
+            size: mem::size_of_val(value),
+            lifetime: PhantomData,
+        };
+    }
+
+    /// Returns an EventDataDescriptor for a variable-length array field.
+    ///
+    /// Resulting descriptor's size is the minimum of:
+    /// - `size_of::<T>() * 65535`
+    /// - `size_of::<T>() * value.len()`
+    pub fn from_slice<T: Copy>(mut value: &'a [T]) -> Self {
+        let value_len = value.len();
+
+        const MAX_LEN: usize = 65535;
+        if MAX_LEN < value_len {
+            value = &value[..MAX_LEN];
+        }
+
+        return Self {
+            ptr: value.as_ptr() as usize,
+            size: mem::size_of_val(value),
+            lifetime: PhantomData,
+        };
+    }
+}

--- a/tracepoint/src/lib.rs
+++ b/tracepoint/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#![no_std]
+#![warn(missing_docs)]
+#![allow(clippy::needless_return)]
+
+//! # Linux Tracepoints
+
+// Exports from tracepoint:
+pub use descriptors::EventDataDescriptor;
+pub use native::NativeImplementation;
+pub use native::TracepointState;
+pub use native::NATIVE_IMPLEMENTATION;
+pub mod changelog;
+
+mod descriptors;
+mod native;


### PR DESCRIPTION
This PR splits the low-level tracepoint building blocks out into a separate crate. The `tracepoint` crate exposes the `EventDataDescriptor` and `TracepointState` types. These were previously part of the `_internal` module of the `eventheader` crate.

- New `tracepoint` crate contains `EventDataDescriptor` and `TracepointState`.
- Update doc comments on these because they're now "public".
- eventheader crate now depends on `tracepoint` crate, no longer depends directly on `libc`, no longer has any native stuff.
- `write_eventheader` is no longer a method on `TracepointState`. It is now a free function (`TracepointState` moved to `tracepoint` crate, but `tracepoint` crate shouldn't do eventheader stuff).
- Fix clippy warnings reported in `eventheader_macros`.

Possible future work:

- Macro-based non-eventheader eventing system (`Provider` class and macros, similar to the `eventheader` crate).
- Runtime-dynamic non-eventheader eventing system (`Provider` and `EventBuilder` classes, similar to the `eventheader_dynamic` crate).