### PR TITLE
BUG FIX: Fix EADDRINUSE returned during register

### DIFF
--- a/eventheader/src/_internal.rs
+++ b/eventheader/src/_internal.rs
@@ -24,7 +24,7 @@ pub use crate::provider::EventHeaderTracepoint;
 
 /// Type string for use in the DIAG_IOCSREG command string.
 pub const EVENTHEADER_COMMAND_TYPES: &str =
-    "u8 eventheader_flags;u8 version;u16 id;u16 tag;u8 opcode;u8 level";
+    "u8 eventheader_flags; u8 version; u16 id; u16 tag; u8 opcode; u8 level";
 
 /// Maximum length of a Tracepoint name "ProviderName_Attributes\0" (includes nul).
 pub const EVENTHEADER_NAME_MAX: usize = 256;

--- a/eventheader/src/changelog.rs
+++ b/eventheader/src/changelog.rs
@@ -6,11 +6,15 @@
 #[allow(unused_imports)]
 use crate::*; // For docs
 
-/// # v0.4.0 (TBD)
+/// # v0.4.0 (2024-04-12)
+/// - BUG FIX: Fix `EADDRINUSE` returned during `register()` on newer kernels.
+///   The "name already in use" detection splits on whitespace, while all other
+///   processing splits on semicolon. Fix by adding space after each semicolon
+///   in `EVENTHEADER_COMMAND_TYPES`.
 /// - Move non-eventheader code into separate `tracepoint` crate.
 pub mod v0_4_0 {}
 
-/// # v0.3.5 (2023-02-27)
+/// # v0.3.5 (2024-02-27)
 /// - Open `user_events_data` for WRONLY instead of RDWR.
 pub mod v0_3_5 {}
 

--- a/eventheader/src/provider.rs
+++ b/eventheader/src/provider.rs
@@ -332,7 +332,7 @@ impl Write for CommandStringBuffer {
 }
 
 /// Helper for creating a command string for registering a tracepoint, e.g.
-/// `ProviderName_L1K1f u8 eventheader_flags;u8 version;u16 id;u16 tag;u8 opcode;u8 level`.
+/// `ProviderName_L1K1f u8 eventheader_flags; u8 version; u16 id; u16 tag; u8 opcode; u8 level`.
 pub struct CommandString(CommandStringBuffer);
 
 impl CommandString {
@@ -345,7 +345,7 @@ impl CommandString {
     }
 
     /// Gets the CStr for the specified parameters:
-    /// `ProviderName_LnnKnn... u8 eventheader_flags;u8 version;u16 id;u16 tag;u8 opcode;u8 level`.
+    /// `ProviderName_LnnKnn... u8 eventheader_flags; u8 version; u16 id; u16 tag; u8 opcode; u8 level`.
     pub fn format(
         &mut self,
         provider_name: &[u8],


### PR DESCRIPTION
BUG FIX: Fix `EADDRINUSE` returned during `register()` on newer kernels. The "name already in use" detection splits on whitespace, while all other processing splits on semicolon. Fix by adding space after each semicolon in `EVENTHEADER_COMMAND_TYPES`.