### PR TITLE
PR feedback for perf decoding

### DIFF
--- a/tracepoint_decode/src/perf_event_data.rs
+++ b/tracepoint_decode/src/perf_event_data.rs
@@ -142,13 +142,21 @@ impl<'a> PerfNonSampleEventInfo<'a> {
     }
 
     /// Returns true if the the session's event data is formatted in big-endian
-    /// byte order. (Use `byte_reader()` to do byte-swapping as appropriate.)
+    /// byte order.
+    ///
+    /// If directly accessing the session's event data, you may want to use
+    /// `byte_reader()` to help with reading values since it will automatically
+    /// perform appropriate byte-swapping based on the data source's byte order.
     pub const fn source_big_endian(&self) -> bool {
         self.session_info.source_big_endian()
     }
 
     /// Returns a [`PerfByteReader`] configured for the byte order of the events
     /// in this session, i.e. `PerfByteReader::new(source_big_endian())`.
+    ///
+    /// If directly accessing the session's event data, you may want to use
+    /// `byte_reader()` to help with reading values since it will automatically
+    /// perform appropriate byte-swapping based on the data source's byte order.
     pub const fn byte_reader(&self) -> PerfByteReader {
         self.session_info.byte_reader()
     }
@@ -197,7 +205,7 @@ impl<'a> PerfNonSampleEventInfo<'a> {
     ///   (assumes the clock value is in nanoseconds), or omitted if not present.
     /// - `"cpu": 3` (omitted if unavailable)
     /// - `"pid": 123` (omitted if unavailable)
-    /// - `"tid": 124` (omitted if unavailable or redundant)
+    /// - `"tid": 124` (omitted if unavailable or if pid is shown and pid == tid)
     /// - `"provider": "SystemName"` (omitted if unavailable)
     /// - `"event": "TracepointName"` (omitted if unavailable)
     pub const fn json_meta_display(&self) -> JsonMetaDisplay {
@@ -319,13 +327,21 @@ impl<'a> PerfSampleEventInfo<'a> {
     }
 
     /// Returns true if the the session's event data is formatted in big-endian
-    /// byte order. (Use `byte_reader()` to do byte-swapping as appropriate.)
+    /// byte order.
+    ///
+    /// If directly accessing the session's event data, you may want to use
+    /// `byte_reader()` to help with reading values since it will automatically
+    /// perform appropriate byte-swapping based on the data source's byte order.
     pub const fn source_big_endian(&self) -> bool {
         self.session_info.source_big_endian()
     }
 
     /// Returns a [`PerfByteReader`] configured for the byte order of the events
     /// in this session, i.e. `PerfByteReader::new(source_big_endian())`.
+    ///
+    /// If directly accessing the session's event data, you may want to use
+    /// `byte_reader()` to help with reading values since it will automatically
+    /// perform appropriate byte-swapping based on the data source's byte order.
     pub const fn byte_reader(&self) -> PerfByteReader {
         self.session_info.byte_reader()
     }
@@ -417,7 +433,7 @@ impl<'a> PerfSampleEventInfo<'a> {
     ///   (assumes the clock value is in nanoseconds), or omitted if not present.
     /// - `"cpu": 3` (omitted if unavailable)
     /// - `"pid": 123` (omitted if unavailable)
-    /// - `"tid": 124` (omitted if unavailable or redundant)
+    /// - `"tid": 124` (omitted if unavailable or if pid is shown and pid == tid)
     /// - `"provider": "SystemName"` (omitted if unavailable)
     /// - `"event": "TracepointName"` (omitted if unavailable)
     pub const fn json_meta_display(&self) -> JsonMetaDisplay {

--- a/tracepoint_decode/src/perf_event_format.rs
+++ b/tracepoint_decode/src/perf_event_format.rs
@@ -13,6 +13,10 @@ use perf_field_format::ascii_to_u32;
 use perf_field_format::consume_string;
 use perf_field_format::is_space_or_tab;
 
+/// This macro is used in certain edge cases that I don't expect to happen in normal
+/// `format` files. The code treats these as errors. The macro provides an easy way
+/// to make an instrumented build that reports these cases.
+///
 /// At present, does nothing.
 macro_rules! debug_eprintln {
     ($($arg:tt)*) => {};

--- a/tracepoint_decode/src/perf_field_format.rs
+++ b/tracepoint_decode/src/perf_field_format.rs
@@ -10,6 +10,10 @@ use alloc::string;
 use crate::*;
 use eventheader_types::*;
 
+/// This macro is used in certain edge cases that I don't expect to happen in normal
+/// `format` files. The code treats these as errors. The macro provides an easy way
+/// to make an instrumented build that reports these cases.
+///
 /// At present, does nothing.
 macro_rules! debug_eprintln {
     ($($arg:tt)*) => {};

--- a/tracepoint_perf/src/file_writer.rs
+++ b/tracepoint_perf/src/file_writer.rs
@@ -766,6 +766,8 @@ impl DataFileWriter {
             append_value::<u32>(header, &((name_size + name_pad) as u32)); // event_string.len
             header.extend_from_slice(&name[..name_size]); // event_string.string
             header.resize(header.len() + name_pad, 0); // NUL + pad to x8
+
+            // SAFETY: Conversion from &[u64] len=N to &[u8] len=8*N.
             header.extend_from_slice(unsafe {
                 slice::from_raw_parts(
                     desc.sample_ids.as_ptr() as *const u8,
@@ -839,6 +841,7 @@ impl DataFileWriter {
         }
 
         for desc in &self.event_descs {
+            // SAFETY: Conversion from &[u64] len=N to &[u8] len=8*N.
             file.write_all(unsafe {
                 slice::from_raw_parts(
                     desc.sample_ids.as_ptr() as *const u8,
@@ -867,6 +870,7 @@ fn append_value<T>(buf: &mut vec::Vec<u8>, value: &T)
 where
     T: Copy, // Proxy for "T is a plain-old-data struct"
 {
+    // SAFETY: Conversion from &T to &[u8] of length size_of::<T>().
     buf.extend_from_slice(unsafe {
         slice::from_raw_parts(value as *const T as *const u8, mem::size_of::<T>())
     });

--- a/tracepoint_perf/src/output_file.rs
+++ b/tracepoint_perf/src/output_file.rs
@@ -61,10 +61,11 @@ impl OutputFile {
         return Ok(written);
     }
 
-    pub fn write_struct<T>(&mut self, value: &T) -> io::Result<()>
+    pub(crate) fn write_struct<T>(&mut self, value: &T) -> io::Result<()>
     where
         T: Copy, // Proxy for "T is a plain-old-data struct"
     {
+        // SAFETY: Reading from the underlying bytes of T.
         return self.write_all(unsafe {
             slice::from_raw_parts(value as *const T as *const u8, mem::size_of::<T>())
         });


### PR DESCRIPTION
Mostly just updating comments.

- Clarify the expected usage of the EventData `source_big_endian` and `byte_reader` methods.
- Clarify the conditions when the `tid` field would be considered redundant.
- Explain the intended purpose of the `debug_eprintln` macro.
- In rewrite_perf sample's `merge_event_desc` function, reuse a buffer instead of repeatedly allocating and freeing a buffer.
- Better `SAFETY` comments.
- Use explicit types in call to `transmute_copy`.
- Methods that treat `Copy` as a proxy for `POD` are now all explicitly crate-private.
- Split one large `unsafe` block into two smaller `unsafe` blocks.