### PR TITLE
Clean up warnings from newer Rust versions

### DIFF
--- a/eventheader/src/_internal.rs
+++ b/eventheader/src/_internal.rs
@@ -102,8 +102,10 @@ pub const fn time_from_duration_before_1970(duration: Duration) -> i64 {
 /// Caller is responsible for making sure there is sufficient space in the buffer.
 unsafe fn append_bytes<T: Sized>(dst: *mut u8, src: &T) -> *mut u8 {
     let size = mem::size_of::<T>();
-    ptr::copy_nonoverlapping(src as *const T as *const u8, dst, size);
-    return dst.add(size);
+    unsafe {
+        ptr::copy_nonoverlapping(src as *const T as *const u8, dst, size);
+        return dst.add(size);
+    }
 }
 
 /// Fills in `data[0]` with the event's write_index, event_header,

--- a/tracepoint_decode/src/perf_field_format.rs
+++ b/tracepoint_decode/src/perf_field_format.rs
@@ -98,6 +98,7 @@ impl PerfFieldFormat {
         size: u16,
         signed: Option<bool>,
     ) -> Self {
+        #[cfg(debug_assertions)]
         const SIZEOF_U8: u16 = 1;
         const SIZEOF_U16: u16 = 2;
         const SIZEOF_U32: u16 = 4;

--- a/tracepoint_decode/src/writers.rs
+++ b/tracepoint_decode/src/writers.rs
@@ -210,6 +210,7 @@ impl<'wri, W: fmt::Write + ?Sized> JsonWriter<'wri, W> {
 
     /// For use before a value or member.
     /// Writes: comma?-newline-indent? i.e. `,\n  `.
+    #[cfg(test)]
     pub fn write_newline_before_value(&mut self, indent: usize) -> fmt::Result {
         if self.0.json_comma {
             self.0.dest.write_ascii(b',')?;
@@ -234,6 +235,7 @@ impl<'wri, W: fmt::Write + ?Sized> JsonWriter<'wri, W> {
     }
 
     /// Writes: `, "escaped-name":`
+    #[cfg(test)]
     pub fn write_property_name(&mut self, name: &str) -> fmt::Result {
         self.write_raw_comma_space()?;
         self.0.json_comma = false;
@@ -760,8 +762,9 @@ impl<'wri, W: fmt::Write + ?Sized> ValueWriter<'wri, W> {
 
     /// Writes e.g. `a3a2a1a0-b1b0-c1c0-d7d6-d5d4d3d2d1d0`.
     pub fn write_uuid(&mut self, value: &[u8; 16]) -> fmt::Result {
+        let tmp = Guid::from_bytes_be(value).to_utf8_bytes();
         return self.dest.write_str(unsafe {
-            str::from_utf8_unchecked(&Guid::from_bytes_be(value).to_utf8_bytes())
+            str::from_utf8_unchecked(&tmp)
         });
     }
 


### PR DESCRIPTION
- [unsafe_op_in_unsafe_fn](https://doc.rust-lang.org/nightly/rustc/lints/listing/allowed-by-default.html#unsafe-op-in-unsafe-fn)
  - Lint is "allow" by default in 2021 edition, but "warn" by default in 2024 edition. Should be safe to address even without bumping the minimum supported Rust version.
- dead code (used only in test or specific configs)
- ["temporary value goes out of scope before references to it do"](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html#temporary-scope-may-be-narrowed)
  - The unsafe { } block around the temporary causes the scope to change between 2021 and 2024, but the fix is safe for both versions.