### PR TITLE
Remove references to static muts

### DIFF
--- a/eventheader_macros/src/enabled_generator.rs
+++ b/eventheader_macros/src/enabled_generator.rs
@@ -55,13 +55,11 @@ impl EnabledGenerator {
                     .drain(),
             )
             .add_punct(";")
-            // identity::<&* const usize>(&_eh_define_provider_MY_PROVIDER) // ensure compile error for aliased provider symbol
+            // identity::<&usize>(&_eh_define_provider_MY_PROVIDER) // ensure compile error for aliased provider symbol
             .add_path(IDENTITY_PATH)
             .add_punct("::")
             .add_punct("<")
             .add_punct("&")
-            .add_punct("*")
-            .add_ident("const")
             .add_scalar_type_path(&mut self.tree2, USIZE_PATH, 0)
             .add_punct(">")
             .add_group_paren(

--- a/eventheader_macros/src/event_generator.rs
+++ b/eventheader_macros/src/event_generator.rs
@@ -239,7 +239,7 @@ impl EventGenerator {
         const _EH_KEYWORD = keywords...;
         const _EH_TAGn: u16 = TAGn;
         static _EH_TRACEPOINT = EventHeaderTracepoint::new(...);
-        static _EH_TRACEPOINT_PTR = &_EH_TRACEPOINT;
+        static mut _EH_TRACEPOINT_PTR = &_EH_TRACEPOINT;
         if !_EH_TRACEPOINT.enabled() {
             9u32 // EBADF
         } else {
@@ -309,13 +309,11 @@ impl EventGenerator {
                     .drain(),
             )
             .add_punct(";")
-            // identity::<&* const usize>(&_eh_define_provider_MY_PROVIDER) // ensure compile error for aliased provider symbol
+            // identity::<&usize>(&_eh_define_provider_MY_PROVIDER) // ensure compile error for aliased provider symbol
             .add_path(IDENTITY_PATH)
             .add_punct("::")
             .add_punct("<")
             .add_punct("&")
-            .add_punct("*")
-            .add_ident("const")
             .add_scalar_type_path(&mut self.tree2, USIZE_PATH, 0)
             .add_punct(">")
             .add_group_paren(

--- a/eventheader_macros/src/provider_generator.rs
+++ b/eventheader_macros/src/provider_generator.rs
@@ -128,7 +128,7 @@ impl ProviderGenerator {
             // #[no_mangle]
             .add_punct("#")
             .add_group_square(self.tree1.add_ident("no_mangle").drain())
-            // static _eh_define_provider_MY_PROVIDER: *const usize = ::core::ptr::null();
+            // static _eh_define_provider_MY_PROVIDER: usize = 0;
             .add_ident("static")
             .add_ident(&String::from_iter([PROVIDER_PTR_VAR_PREFIX, &provider_sym]))
             .add_punct(":")

--- a/eventheader_macros/src/provider_generator.rs
+++ b/eventheader_macros/src/provider_generator.rs
@@ -128,16 +128,13 @@ impl ProviderGenerator {
             // #[no_mangle]
             .add_punct("#")
             .add_group_square(self.tree1.add_ident("no_mangle").drain())
-            // static mut _eh_define_provider_MY_PROVIDER: *const usize = ::core::ptr::null();
+            // static _eh_define_provider_MY_PROVIDER: *const usize = ::core::ptr::null();
             .add_ident("static")
-            .add_ident("mut")
             .add_ident(&String::from_iter([PROVIDER_PTR_VAR_PREFIX, &provider_sym]))
             .add_punct(":")
-            .add_punct("*")
-            .add_ident("const")
             .add_path(USIZE_PATH)
             .add_punct("=")
-            .add_path_call(NULL_PATH, [])
+            .add_literal(Literal::usize_unsuffixed(0))
             .add_punct(";")
             // #[cfg(target_os = "linux")]
             .add_cfg_linux()


### PR DESCRIPTION
```
   --> eventheader/tests/tests.rs:119:22
    |
119 |     eh::write_event!(PROV1, "Default");
    |                      ^^^^^ shared reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
    = note: `#[warn(static_mut_refs)]` on by default
```