### PR TITLE
1.91 clippy

### DIFF
--- a/eventheader/Cargo.toml
+++ b/eventheader/Cargo.toml
@@ -21,7 +21,7 @@ categories = [
 ]
 repository = "https://github.com/microsoft/LinuxTracepoints-Rust"
 readme = "README.md"
-rust-version = "1.63"
+rust-version = "1.64"
 
 [features]
 default = ["user_events", "macros"]

--- a/eventheader_dynamic/Cargo.toml
+++ b/eventheader_dynamic/Cargo.toml
@@ -21,7 +21,7 @@ categories = [
 ]
 repository = "https://github.com/microsoft/LinuxTracepoints-Rust"
 readme = "README.md"
-rust-version = "1.63"
+rust-version = "1.64"
 
 [features]
 default = ["user_events"]

--- a/eventheader_dynamic/src/provider.rs
+++ b/eventheader_dynamic/src/provider.rs
@@ -402,7 +402,7 @@ impl Ord for EventSet {
 
 impl PartialOrd for EventSet {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.key.cmp(&other.key))
+        Some(self.cmp(other))
     }
 }
 

--- a/eventheader_macros/Cargo.toml
+++ b/eventheader_macros/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 description = "Rust macros for eventheader-encoded Linux Tracepoints via user_events"
 repository = "https://github.com/microsoft/LinuxTracepoints-Rust"
 readme = "README.md"
-rust-version = "1.63"
+rust-version = "1.64"
 
 [lib]
 proc-macro = true

--- a/eventheader_macros/src/parser.rs
+++ b/eventheader_macros/src/parser.rs
@@ -207,7 +207,7 @@ impl<'a> Parser<'a> {
     /// Reads OptionIdent(ArgsGroup) or {...} then moves to the next comma or the end-of-stream.
     /// Emits "expected option" errors for non-option syntax.
     /// Emits "expected ..." error for other tokens encountered before comma or end-of-stream.
-    pub fn next_arg(&mut self, want_struct: bool) -> ArgResult {
+    pub fn next_arg(&mut self, want_struct: bool) -> ArgResult<'_> {
         const EXPECTED_OPTION: &str = "expected identifier for option name, e.g. Option(args...)";
         const EXPECTED_OPTION_OR_STRUCT: &str =
             "expected '{' for struct or identifier for option name, e.g. Option(args...)";

--- a/eventheader_macros/src/tree.rs
+++ b/eventheader_macros/src/tree.rs
@@ -32,7 +32,7 @@ impl Tree {
         return self;
     }
 
-    pub fn drain(&mut self) -> vec::Drain<TokenTree> {
+    pub fn drain(&mut self) -> vec::Drain<'_, TokenTree> {
         debug_assert!(self.span_stack.is_empty());
         return self.trees.drain(..);
     }

--- a/eventheader_types/Cargo.toml
+++ b/eventheader_types/Cargo.toml
@@ -21,7 +21,7 @@ categories = [
 ]
 repository = "https://github.com/microsoft/LinuxTracepoints-Rust"
 readme = "README.md"
-rust-version = "1.63"
+rust-version = "1.64"
 
 [dependencies]
 

--- a/tracepoint/Cargo.toml
+++ b/tracepoint/Cargo.toml
@@ -20,7 +20,7 @@ categories = [
 ]
 repository = "https://github.com/microsoft/LinuxTracepoints-Rust"
 readme = "README.md"
-rust-version = "1.63"
+rust-version = "1.64"
 
 [features]
 default = ["user_events"]

--- a/tracepoint_decode/Cargo.toml
+++ b/tracepoint_decode/Cargo.toml
@@ -20,7 +20,7 @@ categories = [
 ]
 repository = "https://github.com/microsoft/LinuxTracepoints-Rust"
 readme = "README.md"
-rust-version = "1.63"
+rust-version = "1.74"
 
 [features]
 default = ["rustc_1_77"]

--- a/tracepoint_decode/src/perf_event_data.rs
+++ b/tracepoint_decode/src/perf_event_data.rs
@@ -199,7 +199,7 @@ impl<'a> PerfNonSampleEventInfo<'a> {
     /// value as the [PerfNonSampleEventInfo::name] method, but as a Display object (can
     /// be passed to a format macro) and with JSON escaping applied (control chars,
     /// quotes, and backslashes are escaped)
-    pub fn json_name_display(&self) -> display::JsonEscapeDisplay {
+    pub fn json_name_display(&self) -> display::JsonEscapeDisplay<'_> {
         display::JsonEscapeDisplay::new(self.name())
     }
 
@@ -230,7 +230,7 @@ impl<'a> PerfNonSampleEventInfo<'a> {
     /// - `"tid": 124` (omitted if unavailable or if pid is shown and pid == tid)
     /// - `"provider": "SystemName"` (omitted if unavailable)
     /// - `"event": "TracepointName"` (omitted if unavailable)
-    pub const fn json_meta_display(&self) -> display::EventInfoJsonMetaDisplay {
+    pub const fn json_meta_display(&self) -> display::EventInfoJsonMetaDisplay<'_> {
         display::EventInfoJsonMetaDisplay::new(
             self.session_info,
             self.event_desc,
@@ -398,7 +398,7 @@ impl<'a> PerfSampleEventInfo<'a> {
     /// value as the [PerfSampleEventInfo::name] method, but as a Display object (can
     /// be passed to a format macro) and with JSON escaping applied (control chars,
     /// quotes, and backslashes are escaped)
-    pub fn json_name_display(&self) -> display::JsonEscapeDisplay {
+    pub fn json_name_display(&self) -> display::JsonEscapeDisplay<'_> {
         display::JsonEscapeDisplay::new(self.name())
     }
 
@@ -471,7 +471,7 @@ impl<'a> PerfSampleEventInfo<'a> {
     /// - `"tid": 124` (omitted if unavailable or if pid is shown and pid == tid)
     /// - `"provider": "SystemName"` (omitted if unavailable)
     /// - `"event": "TracepointName"` (omitted if unavailable)
-    pub const fn json_meta_display(&self) -> display::EventInfoJsonMetaDisplay {
+    pub const fn json_meta_display(&self) -> display::EventInfoJsonMetaDisplay<'_> {
         display::EventInfoJsonMetaDisplay::new(
             self.session_info,
             self.event_desc,

--- a/tracepoint_decode/src/perf_item.rs
+++ b/tracepoint_decode/src/perf_item.rs
@@ -901,7 +901,7 @@ impl<'dat> PerfItemValue<'dat> {
     ///
     /// For example, `write!(writer, "{}", value.display())` might generate a string
     /// like `53`, `true`, `Hello`, or `1, 2, 3`.
-    pub fn display(&self) -> display::PerfItemValueDisplay {
+    pub fn display(&self) -> display::PerfItemValueDisplay<'_> {
         return display::PerfItemValueDisplay::new(self);
     }
 
@@ -1192,7 +1192,7 @@ impl<'dat> PerfItemValue<'dat> {
     ///
     /// For example, `write!(str, "{}", value.json_display())` might generate a string
     /// like `53`, `true`, `"Hello"`, or `[1, 2, 3]`.
-    pub fn json_display(&self) -> display::PerfItemValueJsonDisplay {
+    pub fn json_display(&self) -> display::PerfItemValueJsonDisplay<'_> {
         return display::PerfItemValueJsonDisplay::new(self);
     }
 

--- a/tracepoint_decode/src/writers.rs
+++ b/tracepoint_decode/src/writers.rs
@@ -104,7 +104,7 @@ pub mod date_time {
                 tm: unsafe { core::mem::zeroed() },
             };
 
-            if unsafe { core::ptr::null() == libc::gmtime_r(&value, &mut this.tm) } {
+            if unsafe { libc::gmtime_r(&value, &mut this.tm).is_null() } {
                 this.tm.tm_mday = 0;
             }
 

--- a/tracepoint_perf/Cargo.toml
+++ b/tracepoint_perf/Cargo.toml
@@ -19,7 +19,7 @@ categories = [
 ]
 repository = "https://github.com/microsoft/LinuxTracepoints-Rust"
 readme = "README.md"
-rust-version = "1.63"
+rust-version = "1.64"
 
 [dependencies]
 eventheader_types = { version = "= 0.4.1", path = "../eventheader_types" }

--- a/tracepoint_perf/src/file_reader.rs
+++ b/tracepoint_perf/src/file_reader.rs
@@ -243,7 +243,7 @@ impl PerfDataFileReader {
 
     /// Returns the header and data of the current event.
     /// If there is no current event, returns a default-constructed `PerfEventBytes`.
-    pub fn current_event(&self) -> PerfEventBytes {
+    pub fn current_event(&self) -> PerfEventBytes<'_> {
         if self.current.range.len() < PERF_EVENT_HEADER_SIZE {
             return PerfEventBytes::new(PerfEventHeader::default(), &[]);
         } else {


### PR DESCRIPTION
Apply fixes from Clippy 1.91

- mem::transmute::copy is only stable in a const context in 1.74
- hidden lifetimes that are elided elsewhere are confusing
- ffi::c_ulong (and friends) are only stable in 1.64
- partial_cmp should call cmp