### PR TITLE
Mark symbols as used, fix warnings

### DIFF
--- a/eventheader/tests/tests.rs
+++ b/eventheader/tests/tests.rs
@@ -122,7 +122,7 @@ fn define_provider() {
         eh::provider_enabled!(PROV1, eh::Level::Verbose, 1)
     }
 
-    let _u = Unregister(&PROV1);
+    let _u1 = Unregister(&PROV1);
     assert!(!prov1_enabled());
     PROV1.unregister();
     assert!(!prov1_enabled());

--- a/eventheader_dynamic/src/builder.rs
+++ b/eventheader_dynamic/src/builder.rs
@@ -127,7 +127,7 @@ impl<T: BinaryField> BinaryFieldEncoding for T {}
 /// - If appropriate, configure other event options by calling:
 ///   - `builder.id_version(id, ver)` to set a manually-assigned event id and version.
 ///   - `builder.opcode(opcode)` to specify special semantics for the event, e.g.
-///      activity-start or activity-stop.
+///     activity-start or activity-stop.
 /// - Call `builder.write(event_set, activity_id, related_id)` to
 ///   send the event to the kernel.
 ///   - `activity_id` is an optional 128-bit value that can be used during trace
@@ -744,7 +744,7 @@ impl EventBuilder {
     /// - `field_name` should be a short and distinct string that describes the field.
     ///
     /// - `field_value` provides the data for the field as a `&[ELEMENT]`, i.e. `&[u8]`
-    ///    or `&[i8]`.
+    ///   or `&[i8]`.
     ///
     /// - `format` indicates how the decoder should interpret the field data. For example,
     ///   if the field value is a binary blob, you would likely set `format` to

--- a/eventheader_macros/src/event_generator.rs
+++ b/eventheader_macros/src/event_generator.rs
@@ -165,6 +165,9 @@ impl EventGenerator {
                     ])))
                     .drain(),
             )
+            // #[used]
+            .add_punct("#")
+            .add_group_square(self.tree1.add_ident("used").drain())
             // static mut _EH_TRACEPOINT_PTR: *const ehi::EventHeaderTracepoint = &_EH_TRACEPOINT;
             .add_ident("static")
             .add_ident("mut")
@@ -318,18 +321,13 @@ impl EventGenerator {
             .add_punct(">")
             .add_group_paren(
                 self.tree1
-                    .add_ident("unsafe")
-                    .add_group_curly(
-                        self.tree2
-                            .add_punct("&")
-                            .push_span(provider_symbol_span)
-                            .add_ident(&String::from_iter([
-                                PROVIDER_PTR_VAR_PREFIX,
-                                &provider_symbol_string,
-                            ]))
-                            .pop_span()
-                            .drain(),
-                    )
+                    .add_punct("&")
+                    .push_span(provider_symbol_span)
+                    .add_ident(&String::from_iter([
+                        PROVIDER_PTR_VAR_PREFIX,
+                        &provider_symbol_string,
+                    ]))
+                    .pop_span()
                     .drain(),
             )
             .add_punct(";")

--- a/eventheader_macros/src/provider_generator.rs
+++ b/eventheader_macros/src/provider_generator.rs
@@ -128,6 +128,9 @@ impl ProviderGenerator {
             // #[no_mangle]
             .add_punct("#")
             .add_group_square(self.tree1.add_ident("no_mangle").drain())
+            // #[used]
+            .add_punct("#")
+            .add_group_square(self.tree1.add_ident("used").drain())
             // static _eh_define_provider_MY_PROVIDER: usize = 0;
             .add_ident("static")
             .add_ident(&String::from_iter([PROVIDER_PTR_VAR_PREFIX, &provider_sym]))
@@ -138,6 +141,13 @@ impl ProviderGenerator {
             .add_punct(";")
             // #[cfg(target_os = "linux")]
             .add_cfg_linux()
+            // #[allow(static_mut_refs)]
+            .add_outer_attribute(
+                "allow",
+                self.tree1
+                    .add_ident("static_mut_refs")
+                    .drain(),
+            )
             // static MY_PROVIDER: eh::Provider = unsafe { ... };
             .add_ident("static")
             .add_token(provider.symbol)

--- a/tracepoint_decode/Cargo.toml
+++ b/tracepoint_decode/Cargo.toml
@@ -20,7 +20,7 @@ categories = [
 ]
 repository = "https://github.com/microsoft/LinuxTracepoints-Rust"
 readme = "README.md"
-rust-version = "1.74"
+rust-version = "1.64"
 
 [features]
 default = ["rustc_1_77"]

--- a/tracepoint_decode/src/enumerator.rs
+++ b/tracepoint_decode/src/enumerator.rs
@@ -480,7 +480,7 @@ impl<'dat> EventHeaderItemInfo<'dat> {
 /// - Call `context.enumerate(tracepoint_name, event_data)` to get the enumerator for the event.
 ///   - `tracepoint_name` is the name of the tracepoint, e.g. "ProviderName_L1K2".
 ///   - `event_data` is the event's user data, starting with an the `eventheader_flags` header
-///      (starts immediately after the event's common fields).
+///     (starts immediately after the event's common fields).
 /// - Enumerator starts in the `BeforeFirstItem` state.
 /// - Use `event_info()` to get the event's name and attributes.
 /// - Call `move_next()` to move through the event items.

--- a/tracepoint_decode/src/perf_abi.rs
+++ b/tracepoint_decode/src/perf_abi.rs
@@ -1385,7 +1385,7 @@ impl PerfEventHeader {
     /// Reads a PerfEventHeader from a byte array.
     /// - If byte_reader.byte_swap_needed(), returns a byte-swapped copy of `bytes[0..8]`.
     /// - Otherwise, returns `bytes[0..8]`.
-    pub const fn from_bytes(bytes: &[u8; 8], byte_reader: PerfByteReader) -> Self {
+    pub fn from_bytes(bytes: &[u8; 8], byte_reader: PerfByteReader) -> Self {
         let header: PerfEventHeader = unsafe { mem::transmute_copy(bytes) };
         if byte_reader.byte_swap_needed() {
             return header.byte_swap_copy();


### PR DESCRIPTION
Compiler is optimizing-away some event symbols, breaking registration. This causes a link error (when there are zero events) and runtime failures (due to zero events getting registered). Fix by marking these symbols as `#[used]`.

Also fix a few clippy warnings.

tests.rs:
- For clarity, name the "unregister-on-drop" object based on the PROVn that it is unregistering.

event_generator.rs:
- Add `#[used]` to the `_EH_TRACEPOINT_PTR` symbol so that it is not optimized-away so we can use it when registering the provider.
- Clippy is warning about unnecessary use of `unsafe`, so remove `unsafe{ ... }` from the generated code.

provider_generator.rs:
- Add `#[used]` to the `_eh_define_provider_MY_PROVIDER` symbol so that it is not optimized-away so we don't get linker errors on a provider with no events.
- Clippy is warning about static_mut_refs so suppress the warning.

Cargo.toml:
- The other projects work on 1.64+, so use that as the baseline.

perf_abi.rs:
- `const transmute_copy` is not supported until 1.74. Nobody really benefits from this being const, so remove the const.