### PR TITLE
tracepoint_decode: fix panic when decoding string fields

### DIFF
--- a/tracepoint_decode/src/perf_field_format.rs
+++ b/tracepoint_decode/src/perf_field_format.rs
@@ -939,7 +939,7 @@ impl PerfFieldFormat {
         }
 
         let element_size = self.element_size();
-        let mask = element_size as usize - 1;
+        let mask = (element_size as usize).saturating_sub(1);
         if 0 != (bytes.len() & mask) {
             bytes = &bytes[..bytes.len() & !mask];
         }


### PR DESCRIPTION
For string fields element_size is zero which causes panic on arithmetic overflow. As rust by default enables overflow checks in debug builds and disables them in release builds, the panic occurs only debug builds, release builds seemingly working fine and properly decoding strings at least in the cases I have tested.

As the panic happens in get_field_value_with_data_and_reader it's not caught by current tests.