### PR TITLE
Open user_events_data with O_CLOEXEC

### DIFF
--- a/tracepoint/src/native.rs
+++ b/tracepoint/src/native.rs
@@ -36,11 +36,11 @@ fn clear_errno() {
     unsafe { *linux::__errno_location() = 0 };
 }
 
-/// linux::open(path0, O_WRONLY)
+/// linux::open(path0, O_WRONLY | O_CLOEXEC)
 #[cfg(all(target_os = "linux", feature = "user_events"))]
 fn open_wronly(path0: &[u8]) -> ffi::c_int {
     assert!(path0.ends_with(&[0]));
-    return unsafe { linux::open(path0.as_ptr().cast::<ffi::c_char>(), linux::O_WRONLY) };
+    return unsafe { linux::open(path0.as_ptr().cast::<ffi::c_char>(), linux::O_WRONLY | linux::O_CLOEXEC) };
 }
 
 struct UserEventsDataFile {


### PR DESCRIPTION
When we open /sys/kernel/tracing/user_events_data, we get a fd that we keep alive for future tracing.  Without O_CLOEXEC, this fd is inherited by all child processes.  In some situations, this could cause security issues if a child process is not authorized to write trace events, but has a file descriptor available to do so.  O_CLOEXEC prevents this by ensuring that the fd is closed prior to any fork() to a child process.